### PR TITLE
Add optional `mime_types` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,42 @@ priority = 0
 run = "cat $PATH $ARGS"
 ```
 
+### MIME type filtering
+
+It can sometimes be useful to group related actions by broad categories of file types. The optional `mime_types`
+value specifies a list of [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+patterns. An action will only match a file if it matches both the path pattern and at least one `mime_types` pattern.
+For example:
+
+```toml
+# Use rich with no arguments for Python files
+[[actions.view."*.py"]]
+run = "rich $PATH $ARGS"
+
+# Use timg as the default viewer for image files, regardless of file extension
+[[actions.view."*"]]
+mime_types = ["image/*"]
+run = 'timg $PATH $ARGS'
+
+# Use rich with fancy styling for all other files
+[[actions.view."*"]]
+run = 'rich --panel rounded --theme github-dark --line-numbers --pager $PATH $ARGS'
+```
+
+Leaving `mime_types` unset is equivalent to setting `mime_types = ["*"]`.
+
+**Note:** The Linux [file](https://www.man7.org/linux/man-pages/man1/file.1.html) command and Python's
+[mimetypes module](https://docs.python.org/3/library/mimetypes.html#module-mimetypes) are both helpful for checking the MIME
+type of an existing file. Here are two ways to confirm that `myimage.png` is of type `image/png`:
+
+```console
+$ file --mime myimage.png
+myimage.png: image/png; charset=binary
+
+$ python -m mimetypes myimage.png
+type: image/png encoding: None
+```
+
 ## Why did I build this?
 
 I've always felt something like this should exist.

--- a/src/textualize_see/file_map.py
+++ b/src/textualize_see/file_map.py
@@ -42,14 +42,14 @@ class FileMap:
         """Get commands associated with a path."""
 
         results: list[Command] = []
-        mime_type, _ = mimetypes.guess_type(path)
+        path_mime_type, _ = mimetypes.guess_type(path)
         for wildcard, commands in self.config.paths.items():
             if Path(path).resolve().match(wildcard):
                 for command in commands:
-                    mime_types = command.mime_types
+                    command_mime_types = command.mime_types
                     if (
                         command.action == action and
-                        any(fnmatch(mime_type, pat) for pat in mime_types)
+                        any(fnmatch(path_mime_type, t) for t in command_mime_types)
                     ):
                         results.append(command)
         results.sort(key=attrgetter("priority"), reverse=True)

--- a/src/textualize_see/file_map.py
+++ b/src/textualize_see/file_map.py
@@ -46,10 +46,9 @@ class FileMap:
         for wildcard, commands in self.config.paths.items():
             if Path(path).resolve().match(wildcard):
                 for command in commands:
-                    command_mime_types = command.mime_types
                     if (
                         command.action == action and
-                        any(fnmatch(path_mime_type, t) for t in command_mime_types)
+                        any(fnmatch(path_mime_type, mt) for mt in command.mime_types)
                     ):
                         results.append(command)
         results.sort(key=attrgetter("priority"), reverse=True)

--- a/src/textualize_see/file_map.py
+++ b/src/textualize_see/file_map.py
@@ -97,7 +97,7 @@ class FileMap:
                     mime_types = extension_config.get("mime_types", ["*"])
                     if not isinstance(mime_types, list):
                         raise AppError(
-                            f"Config invalid: [[{action}.{ext}]] / 'mime_pattern' expected list, found {mime_pattern!r}"
+                            f"Config invalid: [[{action}.{ext}]] / 'mime_types' expected list[str], found {mime_types!r}"
                         )
                     extension = Command(action, run, priority, mime_types)
                     config.paths.setdefault(ext, []).append(extension)


### PR DESCRIPTION
This is an unsolicited PR based on what may be a very personal issue, so _please_ feel free to ignore/reject/pivot/etc. That said...

I was playing with this locally and found that I wanted to be able to say something like "if you see an image do this, otherwise do that". It feels a bit like treating `~/.see.toml` as a terminal-focused, more flexible/readable cousin of files like [mimeapps.list](https://wiki.archlinux.org/title/XDG_MIME_Applications#mimeapps.list) or [mailcap.order](https://www.systutorials.com/docs/linux/man/5-mailcap.order/) (which seems at least directionally in line with this project's motivation).

This change helped me condense some configuration while exploring (the kitty gymnastics are a [separate story](https://dev.to/ajkerrigan/kitty-image-quality-in-the-terminal-without-giving-up-tmux-16be) :see_no_evil: ):

```toml
# [[actions.view."*.png"]]
# run = "kitty @ --to unix:/tmp/kitty_remote_control launch --type=tab --title=$PATH --no-response /bin/bash -c \"timg -pk -B gray --title=\\\"%f (%wx%h)\\\" $ARGS \\\"$(realpath $PATH)\\\" && read -sn1\""
# 
# [[actions.view."*.svg"]]
# run = "kitty @ --to unix:/tmp/kitty_remote_control launch --type=tab --title=$PATH --no-response /bin/bash -c \"timg -pk -B gray --title=\\\"%f (%wx%h)\\\" $ARGS \\\"$(realpath $PATH)\\\" && read -sn1\""

[[actions.view."*"]]
mime_types = ["image/*"]
run = ''' 
    kitty @ --to unix:/tmp/kitty_remote_control launch --type=tab --title=$PATH --no-response \
        /bin/bash -c "timg -pk -B gray --title=\"%f (%wx%h)\" $ARGS \"$(realpath $PATH)\" && read -sn1"
'''

[[actions.view."*"]]
run = 'rich --panel rounded --theme github-dark --line-numbers --pager $PATH $ARGS'
```