### PR TITLE
Fix no_run

### DIFF
--- a/src/textualize_see/cli.py
+++ b/src/textualize_see/cli.py
@@ -49,6 +49,7 @@ def app(config: str, no_run: bool, path: str, forward_args: list[str]) -> None:
         run = command.run.replace("$ARGS", args).replace("$PATH", shlex.quote(path))
         if no_run:
             print(run)
+            sys.exit()
         else:
             sys.exit(os.system(run))
         break


### PR DESCRIPTION
The `--no-run` flag didn’t cause see to exit after printing, instead it failed as if no matching config entry had been found. This PR fixes that.
